### PR TITLE
Remove 3 of 4 warnings

### DIFF
--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -228,7 +228,8 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         size = self._header['NAXIS1'] * self._header['NAXIS2']
         return self._header.get('THEAP', size)
 
-    @deprecated('3.0', alternative='the `.columns` attribute')
+    @deprecated('3.0', alternative='the `~astropy.io.fits.FITS_rec.columns` '
+                                   'attribute')
     def get_coldefs(self):
         """
         Returns the table's column definitions.


### PR DESCRIPTION
This commit fixes 3 of the 4 warnings that adding the attribute summary produces.  The fourth is more complicated, and reveals another problem that I'll want to address in a separate PR to master - @iguananaut , you might want to glance at this and make sure it's ok, because it's in `io.fits`.
