### PR TITLE
Add travis status badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,5 +13,10 @@ and development is occuring at the
 For installation instructions, see the `online documentation <http://docs.astropy.org/>`_
 or  ``docs/install.rst`` in this source distribution.
 
+Jenkins Build Status
+--------------------
 .. image:: http://jenkins.shiningpanda-ci.com/astropy/job/astropy-master-debian-multiconfig/badge/icon
+
+Travis Build Status
+-------------------
 .. image:: https://travis-ci.org/astropy/astropy.png


### PR DESCRIPTION
This adds a badge for travis and puts the two under section headings in the README

See https://github.com/eteq/astropy/tree/mdboom-travis-build-status-badge for what it looks like
