### PR TITLE
Changed jenkins build status badge to https

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ or  ``docs/install.rst`` in this source distribution.
 
 Jenkins Build Status
 --------------------
-.. image:: http://jenkins.shiningpanda-ci.com/astropy/job/astropy-master-debian-multiconfig/badge/icon
+.. image:: https://jenkins.shiningpanda-ci.com/astropy/job/astropy-master-debian-multiconfig/badge/icon
 
 Travis Build Status
 -------------------


### PR DESCRIPTION
Based on http://about.travis-ci.org/docs/user/status-images/#Status-Image-URLs, which says that github doesn't cache https requests.
