### PR TITLE
Create backup of the download cache before deleting it 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -329,6 +329,10 @@ New Features
 
 - ``astropy.utils``
 
+  - Added an optional ``backup`` (default False) argument to
+    ``clear_download_cache`` to create a backup of the cache before deleting
+    it. [#3754]
+
 - ``astropy.vo``
 
 - ``astropy.wcs``
@@ -423,6 +427,10 @@ Bug Fixes
     the namespace clash with the default units. [#3873]
 
 - ``astropy.utils``
+
+  - When calling ``download_file``, create a new download cache if the
+    existing cache was written with a database format not understood by the
+    current Python version in use. [#3754]
 
 - ``astropy.vo``
 


### PR DESCRIPTION
(adds a new optional 'backup' argument to clear_download_cache).  Also includes fixes to correctly determine the urlmap filename on Python 3, and to catch the correct exception from the dbm module on Python 3 (a 'dbm.error' exception is raised, not an ImportError)
